### PR TITLE
리뷰 작성 관련 동시성 이슈 방지 및 테스트 코드 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ subprojects {
     dependencies {
         compileOnly 'org.projectlombok:lombok'
         annotationProcessor 'org.projectlombok:lombok'
+        testCompileOnly 'org.projectlombok:lombok'
+        testAnnotationProcessor 'org.projectlombok:lombok'
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
         testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,7 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/qc-application/build.gradle
+++ b/qc-application/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.11.3")
     testImplementation("org.springframework:spring-tx")
+    testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 }
 
 sourceSets {

--- a/qc-application/src/main/java/com/eager/questioncloud/application/api/creator/CreatorRegisterService.java
+++ b/qc-application/src/main/java/com/eager/questioncloud/application/api/creator/CreatorRegisterService.java
@@ -2,6 +2,7 @@ package com.eager.questioncloud.application.api.creator;
 
 import com.eager.questioncloud.core.domain.creator.Creator;
 import com.eager.questioncloud.core.domain.creator.CreatorProfile;
+import com.eager.questioncloud.core.domain.creator.RegisteredCreatorEvent;
 import com.eager.questioncloud.core.domain.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
@@ -12,7 +13,7 @@ import org.springframework.stereotype.Service;
 public class CreatorRegisterService {
     private final CreatorRegister creatorRegister;
     private final ApplicationEventPublisher applicationEventPublisher;
-    
+
     public Creator register(User user, CreatorProfile creatorProfile) {
         Creator creator = creatorRegister.register(user, creatorProfile);
         applicationEventPublisher.publishEvent(RegisteredCreatorEvent.create(creator));

--- a/qc-application/src/main/java/com/eager/questioncloud/application/api/creator/CreatorStatisticsProcessor.java
+++ b/qc-application/src/main/java/com/eager/questioncloud/application/api/creator/CreatorStatisticsProcessor.java
@@ -61,9 +61,14 @@ public class CreatorStatisticsProcessor {
     @EventListener
     public void updateCreatorReviewStatistics(DeletedReviewEvent event) {
         Question question = questionRepository.get(event.getQuestionId());
-        CreatorStatistics creatorStatistics = creatorStatisticsRepository.findByCreatorId(question.getCreatorId());
-        creatorStatistics.updateReviewStatisticsByDeletedReview(event.getRate());
-        creatorStatisticsRepository.save(creatorStatistics);
+        lockManager.executeWithLock(
+            LockKeyGenerator.generateCreatorStatistics(question.getCreatorId()),
+            () -> {
+                CreatorStatistics creatorStatistics = creatorStatisticsRepository.findByCreatorId(question.getCreatorId());
+                creatorStatistics.updateReviewStatisticsByDeletedReview(event.getRate());
+                creatorStatisticsRepository.save(creatorStatistics);
+            }
+        );
     }
 
     //TODO 문제 결제는 실패인데 이 이벤트만 성공하면 어떻게 처리해야할지 고민해보기

--- a/qc-application/src/main/java/com/eager/questioncloud/application/api/creator/CreatorStatisticsProcessor.java
+++ b/qc-application/src/main/java/com/eager/questioncloud/application/api/creator/CreatorStatisticsProcessor.java
@@ -48,9 +48,14 @@ public class CreatorStatisticsProcessor {
     @EventListener
     public void updateCreatorReviewStatistics(ModifiedReviewEvent event) {
         Question question = questionRepository.get(event.getQuestionId());
-        CreatorStatistics creatorStatistics = creatorStatisticsRepository.findByCreatorId(question.getCreatorId());
-        creatorStatistics.updateReviewStatisticsByModifiedReview(event.getVarianceRate());
-        creatorStatisticsRepository.save(creatorStatistics);
+        lockManager.executeWithLock(
+            LockKeyGenerator.generateCreatorStatistics(question.getCreatorId()),
+            () -> {
+                CreatorStatistics creatorStatistics = creatorStatisticsRepository.findByCreatorId(question.getCreatorId());
+                creatorStatistics.updateReviewStatisticsByModifiedReview(event.getVarianceRate());
+                creatorStatisticsRepository.save(creatorStatistics);
+            }
+        );
     }
 
     @EventListener

--- a/qc-application/src/main/java/com/eager/questioncloud/application/api/hub/QuestionHubReviewService.java
+++ b/qc-application/src/main/java/com/eager/questioncloud/application/api/hub/QuestionHubReviewService.java
@@ -45,7 +45,7 @@ public class QuestionHubReviewService {
         questionReviewRepository.save(questionReview);
         applicationEventPublisher.publishEvent(ModifiedReviewEvent.create(questionReview.getQuestionId(), varianceRate));
     }
-    
+
     public void delete(Long reviewId, Long userId) {
         QuestionReview questionReview = questionReviewRepository.findByIdAndUserId(reviewId, userId);
         questionReview.delete();

--- a/qc-application/src/main/java/com/eager/questioncloud/application/api/hub/QuestionHubReviewService.java
+++ b/qc-application/src/main/java/com/eager/questioncloud/application/api/hub/QuestionHubReviewService.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 public class QuestionHubReviewService {
     private final QuestionReviewRepository questionReviewRepository;
     private final QuestionHubReviewRegister questionHubReviewRegister;
+    private final QuestionHunReviewUpdater questionHubReviewUpdater;
     private final ApplicationEventPublisher applicationEventPublisher;
 
     public int getTotal(Long questionId) {
@@ -40,9 +41,7 @@ public class QuestionHubReviewService {
 
     public void modify(Long reviewId, Long userId, String comment, int rate) {
         QuestionReview questionReview = questionReviewRepository.findByIdAndUserId(reviewId, userId);
-        int varianceRate = rate - questionReview.getRate();
-        questionReview.modify(comment, rate);
-        questionReviewRepository.save(questionReview);
+        int varianceRate = questionHubReviewUpdater.modifyQuestionReview(questionReview, comment, rate);
         applicationEventPublisher.publishEvent(ModifiedReviewEvent.create(questionReview.getQuestionId(), varianceRate));
     }
 

--- a/qc-application/src/main/java/com/eager/questioncloud/application/api/hub/QuestionHunReviewUpdater.java
+++ b/qc-application/src/main/java/com/eager/questioncloud/application/api/hub/QuestionHunReviewUpdater.java
@@ -1,0 +1,19 @@
+package com.eager.questioncloud.application.api.hub;
+
+import com.eager.questioncloud.core.domain.review.QuestionReview;
+import com.eager.questioncloud.core.domain.review.QuestionReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class QuestionHunReviewUpdater {
+    private final QuestionReviewRepository questionReviewRepository;
+
+    public int modifyQuestionReview(QuestionReview questionReview, String comment, int rate) {
+        int varianceRate = rate - questionReview.getRate();
+        questionReview.modify(comment, rate);
+        questionReviewRepository.save(questionReview);
+        return varianceRate;
+    }
+}

--- a/qc-application/src/main/java/com/eager/questioncloud/application/api/user/register/RegisterUserService.java
+++ b/qc-application/src/main/java/com/eager/questioncloud/application/api/user/register/RegisterUserService.java
@@ -26,6 +26,7 @@ public class RegisterUserService {
     private final SocialAPIManager socialAPIManager;
     private final EmailSender emailSender;
 
+    //TODO UserPoint 초기화
     public User create(CreateUser createUser) {
         UserAccountInformation userAccountInformation = createUserAccountInformation(createUser);
         UserInformation userInformation = UserInformation.create(createUser);

--- a/qc-application/src/test/java/com/eager/questioncloud/application/api/creator/CreatorStatisticsProcessorTest.java
+++ b/qc-application/src/test/java/com/eager/questioncloud/application/api/creator/CreatorStatisticsProcessorTest.java
@@ -1,0 +1,93 @@
+package com.eager.questioncloud.application.api.creator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.eager.questioncloud.core.domain.creator.Creator;
+import com.eager.questioncloud.core.domain.creator.CreatorEntity;
+import com.eager.questioncloud.core.domain.creator.CreatorJpaRepository;
+import com.eager.questioncloud.core.domain.creator.CreatorProfile;
+import com.eager.questioncloud.core.domain.creator.CreatorStatistics;
+import com.eager.questioncloud.core.domain.creator.CreatorStatisticsEntity;
+import com.eager.questioncloud.core.domain.creator.CreatorStatisticsJpaRepository;
+import com.eager.questioncloud.core.domain.question.Question;
+import com.eager.questioncloud.core.domain.question.QuestionContent;
+import com.eager.questioncloud.core.domain.question.QuestionEntity;
+import com.eager.questioncloud.core.domain.question.QuestionJpaRepository;
+import com.eager.questioncloud.core.domain.question.Subject;
+import com.eager.questioncloud.core.domain.review.RegisteredReviewEvent;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class CreatorStatisticsProcessorTest {
+    @Autowired
+    private CreatorStatisticsProcessor creatorStatisticsProcessor;
+
+    @Autowired
+    private QuestionJpaRepository questionJpaRepository;
+
+    @Autowired
+    private CreatorStatisticsJpaRepository creatorStatisticsJpaRepository;
+
+    @Autowired
+    private CreatorJpaRepository creatorJpaRepository;
+
+    @AfterEach
+    void tearDown() {
+        questionJpaRepository.deleteAllInBatch();
+        creatorJpaRepository.deleteAllInBatch();
+        creatorStatisticsJpaRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("리뷰 등록 시 크리에이터 평점 통계 업데이트 동시성 이슈 테스트")
+    void creatorStatisticsConcurrencyTestWhenRegisteredReview() throws InterruptedException {
+        //given
+        Creator creator = creatorJpaRepository.save(
+            CreatorEntity.from(Creator.create(1L, CreatorProfile.create(Subject.Mathematics, "tt")))
+        ).toModel();
+
+        creatorStatisticsJpaRepository.save(
+            CreatorStatisticsEntity.from(new CreatorStatistics(creator.getId(), 0, 0, 0, 0, 0.0))
+        ).toModel();
+
+        Question question = questionJpaRepository.save(
+            QuestionEntity.from(Question.create(creator.getId(), QuestionContent.builder().build()))
+        ).toModel();
+
+        RegisteredReviewEvent event = RegisteredReviewEvent.create(question.getId(), 4);
+
+        //when
+        int threadCount = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.execute(() -> {
+                try {
+                    creatorStatisticsProcessor.updateCreatorReviewStatistics(event);
+                } catch (Exception ignored) {
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        //then
+        CreatorStatistics creatorStatistics = creatorStatisticsJpaRepository.findByCreatorId(creator.getId())
+            .get().toModel();
+
+        assertThat(creatorStatistics.getTotalReviewRate()).isEqualTo(400);
+        assertThat(creatorStatistics.getAverageRateOfReview()).isEqualTo(4.0);
+    }
+}

--- a/qc-application/src/test/java/com/eager/questioncloud/application/api/creator/CreatorStatisticsProcessorTest.java
+++ b/qc-application/src/test/java/com/eager/questioncloud/application/api/creator/CreatorStatisticsProcessorTest.java
@@ -14,6 +14,7 @@ import com.eager.questioncloud.core.domain.question.QuestionContent;
 import com.eager.questioncloud.core.domain.question.QuestionEntity;
 import com.eager.questioncloud.core.domain.question.QuestionJpaRepository;
 import com.eager.questioncloud.core.domain.question.Subject;
+import com.eager.questioncloud.core.domain.review.DeletedReviewEvent;
 import com.eager.questioncloud.core.domain.review.ModifiedReviewEvent;
 import com.eager.questioncloud.core.domain.review.RegisteredReviewEvent;
 import java.util.concurrent.CountDownLatch;
@@ -133,5 +134,49 @@ class CreatorStatisticsProcessorTest {
 
         assertThat(creatorStatistics.getTotalReviewRate()).isEqualTo(300);
         assertThat(creatorStatistics.getAverageRateOfReview()).isEqualTo(3.0);
+    }
+
+    @Test
+    @DisplayName("리뷰 삭제 시 크리에이터 평점 통계 업데이트 동시성 이슈 테스트")
+    void creatorStatisticsConcurrencyTestWhenDeletedReview() throws InterruptedException {
+        Creator creator = creatorJpaRepository.save(
+            CreatorEntity.from(Creator.create(1L, CreatorProfile.create(Subject.Mathematics, "tt")))
+        ).toModel();
+
+        creatorStatisticsJpaRepository.save(
+            CreatorStatisticsEntity.from(new CreatorStatistics(creator.getId(), 0, 0, 100, 400, 4.0))
+        ).toModel();
+
+        Question question = questionJpaRepository.save(
+            QuestionEntity.from(Question.create(creator.getId(), QuestionContent.builder().build()))
+        ).toModel();
+
+        DeletedReviewEvent event = DeletedReviewEvent.create(question.getId(), 4);
+
+        //when
+        int threadCount = 80;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.execute(() -> {
+                try {
+                    creatorStatisticsProcessor.updateCreatorReviewStatistics(event);
+                } catch (Exception ignored) {
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        //then
+        CreatorStatistics creatorStatistics = creatorStatisticsJpaRepository.findByCreatorId(creator.getId())
+            .get().toModel();
+
+        assertThat(creatorStatistics.getTotalReviewRate()).isEqualTo(80);
+        assertThat(creatorStatistics.getReviewCount()).isEqualTo(20);
+        assertThat(creatorStatistics.getAverageRateOfReview()).isEqualTo(4.0);
     }
 }

--- a/qc-application/src/test/java/com/eager/questioncloud/application/api/hub/QuestionHubReviewRegisterTest.java
+++ b/qc-application/src/test/java/com/eager/questioncloud/application/api/hub/QuestionHubReviewRegisterTest.java
@@ -1,0 +1,78 @@
+package com.eager.questioncloud.application.api.hub;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.eager.questioncloud.core.domain.question.Question;
+import com.eager.questioncloud.core.domain.question.QuestionContent;
+import com.eager.questioncloud.core.domain.question.QuestionEntity;
+import com.eager.questioncloud.core.domain.question.QuestionJpaRepository;
+import com.eager.questioncloud.core.domain.review.QuestionReview;
+import com.eager.questioncloud.core.domain.review.QuestionReviewJpaRepository;
+import com.eager.questioncloud.core.domain.userquestion.UserQuestion;
+import com.eager.questioncloud.core.domain.userquestion.UserQuestionEntity;
+import com.eager.questioncloud.core.domain.userquestion.UserQuestionJpaRepository;
+import java.time.LocalDateTime;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class QuestionHubReviewRegisterTest {
+    @Autowired
+    private QuestionHubReviewRegister questionHubReviewRegister;
+
+    @Autowired
+    private QuestionJpaRepository questionJpaRepository;
+
+    @Autowired
+    private QuestionReviewJpaRepository questionReviewJpaRepository;
+
+    @Autowired
+    private UserQuestionJpaRepository userQuestionJpaRepository;
+
+    @AfterEach
+    void tearDown() {
+        questionJpaRepository.deleteAllInBatch();
+        questionReviewJpaRepository.deleteAllInBatch();
+        userQuestionJpaRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("리뷰 중복 작성 동시성 테스트")
+    void concurrencyTestWhenRegisterReview() throws InterruptedException {
+        //given
+        Long reviewerId = 1L;
+        Question question = questionJpaRepository.save(QuestionEntity.from(Question.create(1L, QuestionContent.builder().build()))).toModel();
+        QuestionReview questionReview = QuestionReview.create(question.getId(), reviewerId, "comment", 5);
+        userQuestionJpaRepository.save(UserQuestionEntity.from(new UserQuestion(null, reviewerId, question.getId(), false, LocalDateTime.now())));
+
+        //when
+        int threadCount = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.execute(() -> {
+                try {
+                    questionHubReviewRegister.register(questionReview);
+                } catch (Exception ignored) {
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        //then
+        int reviewCount = (int) questionReviewJpaRepository.count();
+        assertThat(reviewCount).isEqualTo(1);
+    }
+}

--- a/qc-core/build.gradle
+++ b/qc-core/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
 
     implementation(project(":qc-exception"))
+    implementation(project(":qc-lock-manager"))
 }
 
 def querydslDir = "src/main/generated"

--- a/qc-core/src/main/java/com/eager/questioncloud/core/domain/creator/CreatorRepository.java
+++ b/qc-core/src/main/java/com/eager/questioncloud/core/domain/creator/CreatorRepository.java
@@ -6,4 +6,6 @@ public interface CreatorRepository {
     CreatorInformation getCreatorInformation(Long creatorId);
 
     Creator save(Creator creator);
+
+    void deleteAllInBatch();
 }

--- a/qc-core/src/main/java/com/eager/questioncloud/core/domain/creator/CreatorRepositoryImpl.java
+++ b/qc-core/src/main/java/com/eager/questioncloud/core/domain/creator/CreatorRepositoryImpl.java
@@ -51,4 +51,9 @@ public class CreatorRepositoryImpl implements CreatorRepository {
     public Creator save(Creator creator) {
         return creatorJpaRepository.save(CreatorEntity.from(creator)).toModel();
     }
+
+    @Override
+    public void deleteAllInBatch() {
+        creatorJpaRepository.deleteAllInBatch();
+    }
 }

--- a/qc-core/src/main/java/com/eager/questioncloud/core/domain/creator/CreatorStatistics.java
+++ b/qc-core/src/main/java/com/eager/questioncloud/core/domain/creator/CreatorStatistics.java
@@ -1,5 +1,6 @@
 package com.eager.questioncloud.core.domain.creator;
 
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
@@ -11,6 +12,7 @@ public class CreatorStatistics {
     private int totalReviewRate;
     private Double averageRateOfReview;
 
+    @Builder
     public CreatorStatistics(Long creatorId, int subscribeCount, int salesCount, int reviewCount, int totalReviewRate, Double averageRateOfReview) {
         this.creatorId = creatorId;
         this.subscribeCount = subscribeCount;

--- a/qc-core/src/main/java/com/eager/questioncloud/core/domain/creator/CreatorStatisticsProcessor.java
+++ b/qc-core/src/main/java/com/eager/questioncloud/core/domain/creator/CreatorStatisticsProcessor.java
@@ -1,7 +1,5 @@
-package com.eager.questioncloud.application.api.creator;
+package com.eager.questioncloud.core.domain.creator;
 
-import com.eager.questioncloud.core.domain.creator.CreatorStatistics;
-import com.eager.questioncloud.core.domain.creator.CreatorStatisticsRepository;
 import com.eager.questioncloud.core.domain.payment.CompletedQuestionPaymentEvent;
 import com.eager.questioncloud.core.domain.question.Question;
 import com.eager.questioncloud.core.domain.question.QuestionRepository;

--- a/qc-core/src/main/java/com/eager/questioncloud/core/domain/creator/CreatorStatisticsRepository.java
+++ b/qc-core/src/main/java/com/eager/questioncloud/core/domain/creator/CreatorStatisticsRepository.java
@@ -8,4 +8,6 @@ public interface CreatorStatisticsRepository {
     void saveAll(List<CreatorStatistics> creatorStatistics);
 
     CreatorStatistics findByCreatorId(Long creatorId);
+
+    void deleteAllInBatch();
 }

--- a/qc-core/src/main/java/com/eager/questioncloud/core/domain/creator/CreatorStatisticsRepositoryImpl.java
+++ b/qc-core/src/main/java/com/eager/questioncloud/core/domain/creator/CreatorStatisticsRepositoryImpl.java
@@ -30,4 +30,9 @@ public class CreatorStatisticsRepositoryImpl implements CreatorStatisticsReposit
             .orElseThrow(() -> new CustomException(Error.NOT_FOUND))
             .toModel();
     }
+
+    @Override
+    public void deleteAllInBatch() {
+        creatorStatisticsJpaRepository.deleteAllInBatch();
+    }
 }

--- a/qc-core/src/main/java/com/eager/questioncloud/core/domain/creator/RegisteredCreatorEvent.java
+++ b/qc-core/src/main/java/com/eager/questioncloud/core/domain/creator/RegisteredCreatorEvent.java
@@ -1,6 +1,5 @@
-package com.eager.questioncloud.application.api.creator;
+package com.eager.questioncloud.core.domain.creator;
 
-import com.eager.questioncloud.core.domain.creator.Creator;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/qc-core/src/main/java/com/eager/questioncloud/core/domain/question/QuestionRepository.java
+++ b/qc-core/src/main/java/com/eager/questioncloud/core/domain/question/QuestionRepository.java
@@ -23,4 +23,6 @@ public interface QuestionRepository {
     List<QuestionInformation> findByCreatorIdWithPaging(Long creatorId, PagingInformation pagingInformation);
 
     int countByCreatorId(Long creatorId);
+
+    void deleteAllInBatch();
 }

--- a/qc-core/src/main/java/com/eager/questioncloud/core/domain/question/QuestionRepositoryImpl.java
+++ b/qc-core/src/main/java/com/eager/questioncloud/core/domain/question/QuestionRepositoryImpl.java
@@ -179,6 +179,11 @@ public class QuestionRepositoryImpl implements QuestionRepository {
         return result;
     }
 
+    @Override
+    public void deleteAllInBatch() {
+        questionJpaRepository.deleteAllInBatch();
+    }
+
     private OrderSpecifier<?> sort(QuestionSortType sort) {
         switch (sort) {
             case Popularity -> {

--- a/qc-core/src/main/java/com/eager/questioncloud/core/domain/review/QuestionReviewRepository.java
+++ b/qc-core/src/main/java/com/eager/questioncloud/core/domain/review/QuestionReviewRepository.java
@@ -12,7 +12,7 @@ public interface QuestionReviewRepository {
 
     QuestionReview findByIdAndUserId(Long reviewId, Long userId);
 
-    Boolean isWritten(Long questionId, Long userId);
+    Boolean isWritten(Long userId, Long questionId);
 
     QuestionReview save(QuestionReview questionReview);
 }

--- a/qc-core/src/main/java/com/eager/questioncloud/core/domain/review/QuestionReviewRepositoryImpl.java
+++ b/qc-core/src/main/java/com/eager/questioncloud/core/domain/review/QuestionReviewRepositoryImpl.java
@@ -94,7 +94,7 @@ public class QuestionReviewRepositoryImpl implements QuestionReviewRepository {
     }
 
     @Override
-    public Boolean isWritten(Long questionId, Long userId) {
+    public Boolean isWritten(Long userId, Long questionId) {
         Long reviewId = jpaQueryFactory.select(questionReviewEntity.id)
             .from(questionReviewEntity)
             .where(

--- a/qc-core/src/main/java/com/eager/questioncloud/core/domain/review/QuestionReviewStatisticsRepository.java
+++ b/qc-core/src/main/java/com/eager/questioncloud/core/domain/review/QuestionReviewStatisticsRepository.java
@@ -4,4 +4,6 @@ public interface QuestionReviewStatisticsRepository {
     QuestionReviewStatistics get(Long questionId);
 
     QuestionReviewStatistics save(QuestionReviewStatistics questionReviewStatistics);
+
+    void deleteAllInBatch();
 }

--- a/qc-core/src/main/java/com/eager/questioncloud/core/domain/review/QuestionReviewStatisticsRepositoryImpl.java
+++ b/qc-core/src/main/java/com/eager/questioncloud/core/domain/review/QuestionReviewStatisticsRepositoryImpl.java
@@ -21,4 +21,9 @@ public class QuestionReviewStatisticsRepositoryImpl implements QuestionReviewSta
     public QuestionReviewStatistics save(QuestionReviewStatistics questionReviewStatistics) {
         return questionReviewStatisticsJpaRepository.save(QuestionReviewStatisticsEntity.from(questionReviewStatistics)).toModel();
     }
+
+    @Override
+    public void deleteAllInBatch() {
+        questionReviewStatisticsJpaRepository.deleteAllInBatch();
+    }
 }

--- a/qc-core/src/main/java/com/eager/questioncloud/core/domain/review/QuestionReviewStatisticsUpdater.java
+++ b/qc-core/src/main/java/com/eager/questioncloud/core/domain/review/QuestionReviewStatisticsUpdater.java
@@ -26,11 +26,15 @@ public class QuestionReviewStatisticsUpdater {
     }
 
     @EventListener
-    @Transactional
     public void updateByModifiedReview(ModifiedReviewEvent event) {
-        QuestionReviewStatistics reviewStatistics = questionReviewStatisticsRepository.get(event.getQuestionId());
-        reviewStatistics.updateByModifyReview(event.getVarianceRate());
-        questionReviewStatisticsRepository.save(reviewStatistics);
+        lockManager.executeWithLock(
+            LockKeyGenerator.generateReviewStatistics(event.getQuestionId()),
+            () -> {
+                QuestionReviewStatistics reviewStatistics = questionReviewStatisticsRepository.get(event.getQuestionId());
+                reviewStatistics.updateByModifyReview(event.getVarianceRate());
+                questionReviewStatisticsRepository.save(reviewStatistics);
+            }
+        );
     }
 
     @EventListener

--- a/qc-core/src/main/java/com/eager/questioncloud/core/domain/review/QuestionReviewStatisticsUpdater.java
+++ b/qc-core/src/main/java/com/eager/questioncloud/core/domain/review/QuestionReviewStatisticsUpdater.java
@@ -1,5 +1,7 @@
 package com.eager.questioncloud.core.domain.review;
 
+import com.eager.questioncloud.lock.LockKeyGenerator;
+import com.eager.questioncloud.lock.LockManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
@@ -9,13 +11,18 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class QuestionReviewStatisticsUpdater {
     private final QuestionReviewStatisticsRepository questionReviewStatisticsRepository;
+    private final LockManager lockManager;
 
     @EventListener
-    @Transactional
     public void updateByRegisteredReview(RegisteredReviewEvent event) {
-        QuestionReviewStatistics reviewStatistics = questionReviewStatisticsRepository.get(event.getQuestionId());
-        reviewStatistics.updateByNewReview(event.getRate());
-        questionReviewStatisticsRepository.save(reviewStatistics);
+        lockManager.executeWithLock(
+            LockKeyGenerator.generateReviewStatistics(event.getQuestionId()),
+            () -> {
+                QuestionReviewStatistics reviewStatistics = questionReviewStatisticsRepository.get(event.getQuestionId());
+                reviewStatistics.updateByNewReview(event.getRate());
+                questionReviewStatisticsRepository.save(reviewStatistics);
+            }
+        );
     }
 
     @EventListener

--- a/qc-core/src/test/java/com/eager/questioncloud/CoreTestSpringApplication.java
+++ b/qc-core/src/test/java/com/eager/questioncloud/CoreTestSpringApplication.java
@@ -1,4 +1,4 @@
-package com.eager.questioncloud.core;
+package com.eager.questioncloud;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/qc-core/src/test/java/com/eager/questioncloud/core/domain/creator/CreatorBuilder.java
+++ b/qc-core/src/test/java/com/eager/questioncloud/core/domain/creator/CreatorBuilder.java
@@ -1,0 +1,21 @@
+package com.eager.questioncloud.core.domain.creator;
+
+import com.eager.questioncloud.core.domain.question.Subject;
+import lombok.Builder;
+
+@Builder
+public class CreatorBuilder {
+    private Long id;
+    @Builder.Default
+    private Long userId = 1L;
+    @Builder.Default
+    private CreatorProfile creatorProfile = CreatorProfile.create(Subject.Biology, "creatorIntroduction");
+
+    public Creator toCreator() {
+        return Creator.builder()
+            .id(id)
+            .userId(userId)
+            .creatorProfile(creatorProfile)
+            .build();
+    }
+}

--- a/qc-core/src/test/java/com/eager/questioncloud/core/domain/creator/CreatorStatisticsBuilder.java
+++ b/qc-core/src/test/java/com/eager/questioncloud/core/domain/creator/CreatorStatisticsBuilder.java
@@ -1,0 +1,30 @@
+package com.eager.questioncloud.core.domain.creator;
+
+import lombok.Builder;
+
+@Builder
+public class CreatorStatisticsBuilder {
+    @Builder.Default
+    private Long creatorId = 1L;
+    @Builder.Default
+    private int subscribeCount = 100;
+    @Builder.Default
+    private int salesCount = 100;
+    @Builder.Default
+    private int reviewCount = 100;
+    @Builder.Default
+    private int totalReviewRate = 100;
+    @Builder.Default
+    private Double averageRateOfReview = 1.0;
+
+    public CreatorStatistics toCreatorStatistics() {
+        return CreatorStatistics.builder()
+            .creatorId(creatorId)
+            .subscribeCount(subscribeCount)
+            .salesCount(salesCount)
+            .reviewCount(reviewCount)
+            .totalReviewRate(totalReviewRate)
+            .averageRateOfReview(averageRateOfReview)
+            .build();
+    }
+}

--- a/qc-core/src/test/java/com/eager/questioncloud/core/domain/creator/CreatorStatisticsBuilder.java
+++ b/qc-core/src/test/java/com/eager/questioncloud/core/domain/creator/CreatorStatisticsBuilder.java
@@ -7,15 +7,15 @@ public class CreatorStatisticsBuilder {
     @Builder.Default
     private Long creatorId = 1L;
     @Builder.Default
-    private int subscribeCount = 100;
+    private int subscribeCount = 0;
     @Builder.Default
-    private int salesCount = 100;
+    private int salesCount = 0;
     @Builder.Default
-    private int reviewCount = 100;
+    private int reviewCount = 0;
     @Builder.Default
-    private int totalReviewRate = 100;
+    private int totalReviewRate = 0;
     @Builder.Default
-    private Double averageRateOfReview = 1.0;
+    private Double averageRateOfReview = 0.0;
 
     public CreatorStatistics toCreatorStatistics() {
         return CreatorStatistics.builder()

--- a/qc-core/src/test/java/com/eager/questioncloud/core/domain/creator/CreatorStatisticsProcessorTest.java
+++ b/qc-core/src/test/java/com/eager/questioncloud/core/domain/creator/CreatorStatisticsProcessorTest.java
@@ -3,7 +3,7 @@ package com.eager.questioncloud.core.domain.creator;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.eager.questioncloud.core.domain.question.Question;
-import com.eager.questioncloud.core.domain.question.QuestionContent;
+import com.eager.questioncloud.core.domain.question.QuestionBuilder;
 import com.eager.questioncloud.core.domain.question.QuestionEntity;
 import com.eager.questioncloud.core.domain.question.QuestionJpaRepository;
 import com.eager.questioncloud.core.domain.question.Subject;
@@ -54,9 +54,7 @@ class CreatorStatisticsProcessorTest {
             CreatorStatisticsEntity.from(new CreatorStatistics(creator.getId(), 0, 0, 0, 0, 0.0))
         ).toModel();
 
-        Question question = questionJpaRepository.save(
-            QuestionEntity.from(Question.create(creator.getId(), QuestionContent.builder().build()))
-        ).toModel();
+        Question question = questionJpaRepository.save(QuestionEntity.from(QuestionBuilder.builder().build().toQuestion())).toModel();
 
         RegisteredReviewEvent event = RegisteredReviewEvent.create(question.getId(), 4);
 
@@ -97,9 +95,7 @@ class CreatorStatisticsProcessorTest {
             CreatorStatisticsEntity.from(new CreatorStatistics(creator.getId(), 0, 0, 100, 0, 0.0))
         ).toModel();
 
-        Question question = questionJpaRepository.save(
-            QuestionEntity.from(Question.create(creator.getId(), QuestionContent.builder().build()))
-        ).toModel();
+        Question question = questionJpaRepository.save(QuestionEntity.from(QuestionBuilder.builder().build().toQuestion())).toModel();
 
         ModifiedReviewEvent event = ModifiedReviewEvent.create(question.getId(), 3);
 
@@ -140,9 +136,7 @@ class CreatorStatisticsProcessorTest {
             CreatorStatisticsEntity.from(new CreatorStatistics(creator.getId(), 0, 0, 100, 400, 4.0))
         ).toModel();
 
-        Question question = questionJpaRepository.save(
-            QuestionEntity.from(Question.create(creator.getId(), QuestionContent.builder().build()))
-        ).toModel();
+        Question question = questionJpaRepository.save(QuestionEntity.from(QuestionBuilder.builder().build().toQuestion())).toModel();
 
         DeletedReviewEvent event = DeletedReviewEvent.create(question.getId(), 4);
 
@@ -185,9 +179,7 @@ class CreatorStatisticsProcessorTest {
             CreatorStatisticsEntity.from(new CreatorStatistics(creator.getId(), 0, 0, 100, 100, 1.0))
         ).toModel();
 
-        Question question = questionJpaRepository.save(
-            QuestionEntity.from(Question.create(creator.getId(), QuestionContent.builder().build()))
-        ).toModel();
+        Question question = questionJpaRepository.save(QuestionEntity.from(QuestionBuilder.builder().build().toQuestion())).toModel();
 
         RegisteredReviewEvent registeredReviewEvent = RegisteredReviewEvent.create(question.getId(), 1);
         ModifiedReviewEvent modifiedReviewEvent = ModifiedReviewEvent.create(question.getId(), 1);

--- a/qc-core/src/test/java/com/eager/questioncloud/core/domain/creator/CreatorStatisticsProcessorTest.java
+++ b/qc-core/src/test/java/com/eager/questioncloud/core/domain/creator/CreatorStatisticsProcessorTest.java
@@ -41,8 +41,8 @@ class CreatorStatisticsProcessorTest {
     }
 
     @Test
-    @DisplayName("리뷰 등록 시 크리에이터 평점 통계 업데이트 동시성 이슈 테스트")
-    void creatorStatisticsConcurrencyTestWhenRegisteredReview() throws InterruptedException {
+    @DisplayName("리뷰 등록 이벤트 크리에이터 평점 통계 업데이트 동시성 이슈 테스트")
+    void creatorStatisticsConcurrencyTestWhenRegisteredReviewEvent() throws InterruptedException {
         //given
         Creator creator = creatorRepository.save(CreatorBuilder.builder().build().toCreator());
         creatorStatisticsRepository.save(
@@ -89,8 +89,8 @@ class CreatorStatisticsProcessorTest {
     }
 
     @Test
-    @DisplayName("리뷰 수정 시 크리에이터 평점 통계 업데이트 동시성 이슈 테스트")
-    void creatorStatisticsConcurrencyTestWhenModifiedReview() throws InterruptedException {
+    @DisplayName("리뷰 수정 이벤트 크리에이터 평점 통계 업데이트 동시성 이슈 테스트")
+    void creatorStatisticsConcurrencyTestWhenModifiedReviewEvent() throws InterruptedException {
         Creator creator = creatorRepository.save(CreatorBuilder.builder().build().toCreator());
         creatorStatisticsRepository.save(
             CreatorStatisticsBuilder
@@ -137,8 +137,8 @@ class CreatorStatisticsProcessorTest {
     }
 
     @Test
-    @DisplayName("리뷰 삭제 시 크리에이터 평점 통계 업데이트 동시성 이슈 테스트")
-    void creatorStatisticsConcurrencyTestWhenDeletedReview() throws InterruptedException {
+    @DisplayName("리뷰 삭제 이벤트 크리에이터 평점 통계 업데이트 동시성 이슈 테스트")
+    void creatorStatisticsConcurrencyTestWhenDeletedReviewEvent() throws InterruptedException {
         Creator creator = creatorRepository.save(CreatorBuilder.builder().build().toCreator());
         creatorStatisticsRepository.save(
             CreatorStatisticsBuilder
@@ -187,7 +187,7 @@ class CreatorStatisticsProcessorTest {
     }
 
     @Test
-    @DisplayName("리뷰 추가, 수정, 삭제가 동시에 일어나는 경우 크리에이터 통계 업데이트 동시성 테스트")
+    @DisplayName("리뷰 추가, 수정, 삭제 이벤트가 동시에 일어나는 경우 크리에이터 통계 업데이트 동시성 테스트")
     void creatorStatisticsConcurrencyTestWhenMultipleEvent() throws InterruptedException {
         //given
         Creator creator = creatorRepository.save(CreatorBuilder.builder().build().toCreator());

--- a/qc-core/src/test/java/com/eager/questioncloud/core/domain/creator/CreatorStatisticsProcessorTest.java
+++ b/qc-core/src/test/java/com/eager/questioncloud/core/domain/creator/CreatorStatisticsProcessorTest.java
@@ -1,14 +1,7 @@
-package com.eager.questioncloud.application.api.creator;
+package com.eager.questioncloud.core.domain.creator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.eager.questioncloud.core.domain.creator.Creator;
-import com.eager.questioncloud.core.domain.creator.CreatorEntity;
-import com.eager.questioncloud.core.domain.creator.CreatorJpaRepository;
-import com.eager.questioncloud.core.domain.creator.CreatorProfile;
-import com.eager.questioncloud.core.domain.creator.CreatorStatistics;
-import com.eager.questioncloud.core.domain.creator.CreatorStatisticsEntity;
-import com.eager.questioncloud.core.domain.creator.CreatorStatisticsJpaRepository;
 import com.eager.questioncloud.core.domain.question.Question;
 import com.eager.questioncloud.core.domain.question.QuestionContent;
 import com.eager.questioncloud.core.domain.question.QuestionEntity;

--- a/qc-core/src/test/java/com/eager/questioncloud/core/domain/question/QuestionBuilder.java
+++ b/qc-core/src/test/java/com/eager/questioncloud/core/domain/question/QuestionBuilder.java
@@ -1,0 +1,42 @@
+package com.eager.questioncloud.core.domain.question;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public class QuestionBuilder {
+    private Long id;
+    @Builder.Default
+    private Long creatorId = 1L;
+    @Builder.Default
+    private QuestionContent questionContent = QuestionContent
+        .builder()
+        .questionCategoryId(1L)
+        .subject(Subject.Biology)
+        .title("questionTitle")
+        .description("questionDescription")
+        .thumbnail("questionThumbnail")
+        .fileUrl("questionFileUrl")
+        .explanationUrl("questionExplanationUrl")
+        .questionType(QuestionType.Past)
+        .questionLevel(QuestionLevel.LEVEL4)
+        .price(1000)
+        .build();
+    @Builder.Default
+    private QuestionStatus questionStatus = QuestionStatus.Available;
+    @Builder.Default
+    private int count = 100;
+    @Builder.Default
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    public Question toQuestion() {
+        return Question.builder()
+            .id(id)
+            .creatorId(creatorId)
+            .questionContent(questionContent)
+            .questionStatus(questionStatus)
+            .count(count)
+            .createdAt(createdAt)
+            .build();
+    }
+}

--- a/qc-core/src/test/java/com/eager/questioncloud/core/domain/review/QuestionReviewStatisticsBuilder.java
+++ b/qc-core/src/test/java/com/eager/questioncloud/core/domain/review/QuestionReviewStatisticsBuilder.java
@@ -1,0 +1,24 @@
+package com.eager.questioncloud.core.domain.review;
+
+import lombok.Builder;
+
+@Builder
+public class QuestionReviewStatisticsBuilder {
+    @Builder.Default
+    private Long questionId = 1L;
+    @Builder.Default
+    private int reviewCount = 0;
+    @Builder.Default
+    private int totalRate = 0;
+    @Builder.Default
+    private double averageRate = 0.0;
+
+    public QuestionReviewStatistics toQuestionReviewStatistics() {
+        return QuestionReviewStatistics.builder()
+            .questionId(questionId)
+            .reviewCount(reviewCount)
+            .totalRate(totalRate)
+            .averageRate(averageRate)
+            .build();
+    }
+}

--- a/qc-core/src/test/java/com/eager/questioncloud/core/domain/review/QuestionReviewStatisticsUpdaterTest.java
+++ b/qc-core/src/test/java/com/eager/questioncloud/core/domain/review/QuestionReviewStatisticsUpdaterTest.java
@@ -3,7 +3,7 @@ package com.eager.questioncloud.core.domain.review;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.eager.questioncloud.core.domain.question.Question;
-import com.eager.questioncloud.core.domain.question.QuestionContent;
+import com.eager.questioncloud.core.domain.question.QuestionBuilder;
 import com.eager.questioncloud.core.domain.question.QuestionEntity;
 import com.eager.questioncloud.core.domain.question.QuestionJpaRepository;
 import java.util.concurrent.CountDownLatch;
@@ -38,7 +38,7 @@ class QuestionReviewStatisticsUpdaterTest {
     @DisplayName("리뷰 작성 시 평점 통계 업데이트 동시성 테스트")
     void reviewStatisticsConcurrencyTestWhenRegisteredReview() throws InterruptedException {
         //given
-        Question question = questionJpaRepository.save(QuestionEntity.from(Question.create(1L, QuestionContent.builder().build()))).toModel();
+        Question question = questionJpaRepository.save(QuestionEntity.from(QuestionBuilder.builder().build().toQuestion())).toModel();
         questionReviewStatisticsJpaRepository.save(QuestionReviewStatisticsEntity.from(QuestionReviewStatistics.create(question.getId())));
         RegisteredReviewEvent event = RegisteredReviewEvent.create(question.getId(), 4);
 
@@ -70,7 +70,7 @@ class QuestionReviewStatisticsUpdaterTest {
     @DisplayName("리뷰 수정 시 평점 통계 업데이트 동시성 테스트")
     void reviewStatisticsConcurrencyTestWhenModifiedReview() throws InterruptedException {
         //given
-        Question question = questionJpaRepository.save(QuestionEntity.from(Question.create(1L, QuestionContent.builder().build()))).toModel();
+        Question question = questionJpaRepository.save(QuestionEntity.from(QuestionBuilder.builder().build().toQuestion())).toModel();
         questionReviewStatisticsJpaRepository.save(
             QuestionReviewStatisticsEntity.from(new QuestionReviewStatistics(question.getId(), 100, 0, 0.0))
         );
@@ -105,7 +105,7 @@ class QuestionReviewStatisticsUpdaterTest {
     @DisplayName("리뷰 삭제 시 평점 통계 업데이트 동시성 테스트")
     void reviewStatisticsConcurrencyTestWhenDeletedReview() throws InterruptedException {
         //given
-        Question question = questionJpaRepository.save(QuestionEntity.from(Question.create(1L, QuestionContent.builder().build()))).toModel();
+        Question question = questionJpaRepository.save(QuestionEntity.from(QuestionBuilder.builder().build().toQuestion())).toModel();
         questionReviewStatisticsJpaRepository.save(
             QuestionReviewStatisticsEntity.from(new QuestionReviewStatistics(question.getId(), 100, 400, 4.0))
         );
@@ -140,7 +140,7 @@ class QuestionReviewStatisticsUpdaterTest {
     @DisplayName("리뷰 추가, 수정, 삭제가 동시에 일어나는 경우 리뷰 통계 평점 업데이트 동시성 테스트")
     void reviewStatisticsConcurrencyTestWhenMultipleEvent() throws InterruptedException {
         //given
-        Question question = questionJpaRepository.save(QuestionEntity.from(Question.create(1L, QuestionContent.builder().build()))).toModel();
+        Question question = questionJpaRepository.save(QuestionEntity.from(QuestionBuilder.builder().build().toQuestion())).toModel();
         questionReviewStatisticsJpaRepository.save(
             QuestionReviewStatisticsEntity.from(new QuestionReviewStatistics(question.getId(), 100, 100, 1.0))
         );

--- a/qc-core/src/test/java/com/eager/questioncloud/core/domain/review/QuestionReviewStatisticsUpdaterTest.java
+++ b/qc-core/src/test/java/com/eager/questioncloud/core/domain/review/QuestionReviewStatisticsUpdaterTest.java
@@ -65,4 +65,39 @@ class QuestionReviewStatisticsUpdaterTest {
         assertThat(questionReviewStatistics.getReviewCount()).isEqualTo(100);
         assertThat(questionReviewStatistics.getTotalRate()).isEqualTo(400);
     }
+
+    @Test
+    @DisplayName("리뷰 수정 시 평점 통계 업데이트 동시성 테스트")
+    void concurrencyTestWhenModifiedReview() throws InterruptedException {
+        //given
+        Question question = questionJpaRepository.save(QuestionEntity.from(Question.create(1L, QuestionContent.builder().build()))).toModel();
+        questionReviewStatisticsJpaRepository.save(
+            QuestionReviewStatisticsEntity.from(new QuestionReviewStatistics(question.getId(), 100, 0, 0.0))
+        );
+        ModifiedReviewEvent event = ModifiedReviewEvent.create(question.getId(), 3);
+
+        //when
+        int threadCount = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.execute(() -> {
+                try {
+                    questionReviewStatisticsUpdater.updateByModifiedReview(event);
+                } catch (Exception ignored) {
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        //then
+        QuestionReviewStatistics questionReviewStatistics = questionReviewStatisticsJpaRepository.findById(question.getId()).get().toModel();
+        assertThat(questionReviewStatistics.getTotalRate()).isEqualTo(300);
+        assertThat(questionReviewStatistics.getReviewCount()).isEqualTo(100);
+        assertThat(questionReviewStatistics.getAverageRate()).isEqualTo(3.0);
+    }
 }

--- a/qc-core/src/test/java/com/eager/questioncloud/core/domain/review/QuestionReviewStatisticsUpdaterTest.java
+++ b/qc-core/src/test/java/com/eager/questioncloud/core/domain/review/QuestionReviewStatisticsUpdaterTest.java
@@ -1,0 +1,68 @@
+package com.eager.questioncloud.core.domain.review;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.eager.questioncloud.core.domain.question.Question;
+import com.eager.questioncloud.core.domain.question.QuestionContent;
+import com.eager.questioncloud.core.domain.question.QuestionEntity;
+import com.eager.questioncloud.core.domain.question.QuestionJpaRepository;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class QuestionReviewStatisticsUpdaterTest {
+    @Autowired
+    private QuestionReviewStatisticsUpdater questionReviewStatisticsUpdater;
+
+    @Autowired
+    private QuestionJpaRepository questionJpaRepository;
+
+    @Autowired
+    private QuestionReviewStatisticsJpaRepository questionReviewStatisticsJpaRepository;
+
+    @AfterEach
+    void tearDown() {
+        questionJpaRepository.deleteAllInBatch();
+        questionReviewStatisticsJpaRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("리뷰 작성 시 평점 통계 업데이트 동시성 테스트")
+    void concurrencyTestWhenRegisteredReview() throws InterruptedException {
+        //given
+        Question question = questionJpaRepository.save(QuestionEntity.from(Question.create(1L, QuestionContent.builder().build()))).toModel();
+        questionReviewStatisticsJpaRepository.save(QuestionReviewStatisticsEntity.from(QuestionReviewStatistics.create(question.getId())));
+        RegisteredReviewEvent event = RegisteredReviewEvent.create(question.getId(), 4);
+
+        //when
+        int threadCount = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.execute(() -> {
+                try {
+                    questionReviewStatisticsUpdater.updateByRegisteredReview(event);
+                } catch (Exception ignored) {
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        //then
+        QuestionReviewStatistics questionReviewStatistics = questionReviewStatisticsJpaRepository.findById(question.getId()).get().toModel();
+        assertThat(questionReviewStatistics.getReviewCount()).isEqualTo(100);
+        assertThat(questionReviewStatistics.getTotalRate()).isEqualTo(400);
+    }
+}

--- a/qc-core/src/test/java/com/eager/questioncloud/core/domain/review/QuestionReviewStatisticsUpdaterTest.java
+++ b/qc-core/src/test/java/com/eager/questioncloud/core/domain/review/QuestionReviewStatisticsUpdaterTest.java
@@ -34,8 +34,8 @@ class QuestionReviewStatisticsUpdaterTest {
     }
 
     @Test
-    @DisplayName("리뷰 작성 시 평점 통계 업데이트 동시성 테스트")
-    void reviewStatisticsConcurrencyTestWhenRegisteredReview() throws InterruptedException {
+    @DisplayName("리뷰 작성 이벤트 평점 통계 업데이트 동시성 테스트")
+    void reviewStatisticsConcurrencyTestWhenRegisteredReviewEvent() throws InterruptedException {
         //given
         Question question = questionRepository.save(QuestionBuilder.builder().build().toQuestion());
         questionReviewStatisticsRepository.save(
@@ -45,7 +45,7 @@ class QuestionReviewStatisticsUpdaterTest {
                 .build()
                 .toQuestionReviewStatistics()
         );
-        
+
         RegisteredReviewEvent event = RegisteredReviewEvent.create(question.getId(), 4);
 
         //when
@@ -73,8 +73,8 @@ class QuestionReviewStatisticsUpdaterTest {
     }
 
     @Test
-    @DisplayName("리뷰 수정 시 평점 통계 업데이트 동시성 테스트")
-    void reviewStatisticsConcurrencyTestWhenModifiedReview() throws InterruptedException {
+    @DisplayName("리뷰 수정 이벤트 평점 통계 업데이트 동시성 테스트")
+    void reviewStatisticsConcurrencyTestWhenModifiedReviewEvent() throws InterruptedException {
         //given
         Question question = questionRepository.save(QuestionBuilder.builder().build().toQuestion());
         questionReviewStatisticsRepository.save(
@@ -113,8 +113,8 @@ class QuestionReviewStatisticsUpdaterTest {
     }
 
     @Test
-    @DisplayName("리뷰 삭제 시 평점 통계 업데이트 동시성 테스트")
-    void reviewStatisticsConcurrencyTestWhenDeletedReview() throws InterruptedException {
+    @DisplayName("리뷰 삭제 이벤트 평점 통계 업데이트 동시성 테스트")
+    void reviewStatisticsConcurrencyTestWhenDeletedReviewEvent() throws InterruptedException {
         //given
         Question question = questionRepository.save(QuestionBuilder.builder().build().toQuestion());
         questionReviewStatisticsRepository.save(
@@ -155,7 +155,7 @@ class QuestionReviewStatisticsUpdaterTest {
     }
 
     @Test
-    @DisplayName("리뷰 추가, 수정, 삭제가 동시에 일어나는 경우 리뷰 통계 평점 업데이트 동시성 테스트")
+    @DisplayName("리뷰 추가, 수정, 삭제 이벤트가 동시에 일어나는 경우 리뷰 통계 평점 업데이트 동시성 테스트")
     void reviewStatisticsConcurrencyTestWhenMultipleEvent() throws InterruptedException {
         //given
         Question question = questionRepository.save(QuestionBuilder.builder().build().toQuestion());

--- a/qc-core/src/test/java/com/eager/questioncloud/core/domain/user/UserRepositoryTest.java
+++ b/qc-core/src/test/java/com/eager/questioncloud/core/domain/user/UserRepositoryTest.java
@@ -7,9 +7,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @ActiveProfiles("test")
+@Transactional
 class UserRepositoryTest {
     @Autowired
     private UserRepository userRepository;

--- a/qc-lock-manager/src/main/java/com/eager/questioncloud/lock/LockKeyGenerator.java
+++ b/qc-lock-manager/src/main/java/com/eager/questioncloud/lock/LockKeyGenerator.java
@@ -12,4 +12,16 @@ public class LockKeyGenerator {
     public static String generateQuestionPaymentKey(Long userId) {
         return "QUESTION-PAYMENT-" + userId;
     }
+
+    public static String generateRegisterReview(Long userId, Long questionId) {
+        return "REGISTER-REVIEW-" + userId + "-" + questionId;
+    }
+
+    public static String generateCreatorStatistics(Long creatorId) {
+        return "CREATOR-STATISTICS-" + creatorId;
+    }
+
+    public static String generateReviewStatistics(Long questionId) {
+        return "REVIEW-STATISTICS-" + questionId;
+    }
 }

--- a/qc-lock-manager/src/main/java/com/eager/questioncloud/lock/LockManager.java
+++ b/qc-lock-manager/src/main/java/com/eager/questioncloud/lock/LockManager.java
@@ -27,17 +27,17 @@ public class LockManager {
             }
             task.run();
         } catch (InterruptedException e) {
-            if (lock.isLocked()) {
+            if (lock.isLocked() && lock.isHeldByCurrentThread()) {
                 lock.unlock();
             }
             throw new CustomException(Error.INTERNAL_SERVER_ERROR);
         } catch (CustomException e) {
-            if (lock.isLocked()) {
+            if (lock.isLocked() && lock.isHeldByCurrentThread()) {
                 lock.unlock();
             }
             throw e;
         } finally {
-            if (lock.isLocked()) {
+            if (lock.isLocked() && lock.isHeldByCurrentThread()) {
                 lock.unlock();
             }
         }


### PR DESCRIPTION
 - 리뷰 작성, 수정, 삭제 이벤트 발생 시 리뷰 통계 업데이트 로직에서 동시성 이슈 방지를 위해 분산락 처리
 - 리뷰 작성, 수정, 삭제 이벤트 발생 시 크리에이터 통계 업데이트 로직에서 동시성 이슈 방지를 위해 분산락 처리